### PR TITLE
Add touch controls and slow ghost

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,19 @@
     margin-top: 10px;
     font-size: 16px;
   }
+  #controls {
+    margin-top: 10px;
+    display: grid;
+    grid-template-columns: 60px 60px 60px;
+    grid-template-rows: 60px 60px 60px;
+    gap: 5px;
+    justify-content: center;
+  }
+  #controls button {
+    width: 60px;
+    height: 60px;
+    font-size: 24px;
+  }
 </style>
 </head>
 <body>
@@ -34,6 +47,12 @@
 <div id="message">
   <h2 id="msgText"></h2>
   <button id="restart">Restart</button>
+</div>
+<div id="controls">
+  <button id="btn-up" style="grid-column: 2; grid-row: 1;">&#9650;</button>
+  <button id="btn-left" style="grid-column: 1; grid-row: 2;">&#9664;</button>
+  <button id="btn-right" style="grid-column: 3; grid-row: 2;">&#9654;</button>
+  <button id="btn-down" style="grid-column: 2; grid-row: 3;">&#9660;</button>
 </div>
 <script>
 const canvas = document.getElementById('game');
@@ -48,6 +67,8 @@ let pacman = { x: 1, y: 1 };
 let ghost = { x: COLS - 2, y: ROWS - 2 };
 let score = 0;
 let gameOver = false;
+const GHOST_SPEED = 10;
+let ghostCounter = 0;
 
 function initMap() {
   map = [];
@@ -132,6 +153,27 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
+function setupTouchControls() {
+  const mapBtn = {
+    'btn-left': [-1, 0],
+    'btn-right': [1, 0],
+    'btn-up': [0, -1],
+    'btn-down': [0, 1],
+  };
+  for (const id in mapBtn) {
+    const btn = document.getElementById(id);
+    ['mousedown', 'touchstart'].forEach((ev) => {
+      btn.addEventListener(ev, (e) => {
+        e.preventDefault();
+        if (gameOver) return;
+        const d = mapBtn[id];
+        moveEntity(pacman, d[0], d[1]);
+        eat();
+      });
+    });
+  }
+}
+
 function eat() {
   if (map[pacman.y][pacman.x] === 2) {
     map[pacman.y][pacman.x] = 0;
@@ -171,7 +213,10 @@ document.getElementById('restart').onclick = () => {
 
 function loop() {
   if (!gameOver) {
-    moveGhost();
+    ghostCounter++;
+    if (ghostCounter % GHOST_SPEED === 0) {
+      moveGhost();
+    }
     checkCollision();
     draw();
     requestAnimationFrame(loop);
@@ -180,6 +225,7 @@ function loop() {
 
 initMap();
 draw();
+setupTouchControls();
 loop();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add on-screen buttons for touch and mouse input
- make ghost move less frequently
- wire up touch controls and keep keyboard controls

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6856824c463c8324a6c1c28b8caa4b69