### PR TITLE
Implement functional Pacman game

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,171 +2,141 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pacman Level</title>
+<title>Pacman</title>
 <style>
-
   body { background:#000; color:#fff; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
   #controls { width:180px; margin:10px auto; display:grid; grid-template-columns:60px 60px 60px; grid-template-rows:60px 60px 60px; gap:5px; }
   #controls button { width:60px; height:60px; font-size:24px; }
-
 </style>
 </head>
 <body>
 <canvas id="game" width="300" height="300"></canvas>
 <div id="controls">
-
   <button id="up" style="grid-column:2;grid-row:1;">&#9650;</button>
   <button id="left" style="grid-column:1;grid-row:2;">&#9664;</button>
   <button id="right" style="grid-column:3;grid-row:2;">&#9654;</button>
   <button id="down" style="grid-column:2;grid-row:3;">&#9660;</button>
 </div>
 <script>
-window.addEventListener('load', () => {
+document.addEventListener('DOMContentLoaded', () => {
+  const canvas = document.getElementById('game');
+  const ctx = canvas.getContext('2d');
+  const CELL = 30;
+  const level = [
+    [1,1,1,1,1,1,1,1,1,1],
+    [1,2,2,2,2,2,2,2,2,1],
+    [1,2,1,1,1,1,1,1,2,1],
+    [1,2,2,2,2,2,2,1,2,1],
+    [1,1,1,1,1,1,2,1,2,1],
+    [1,2,2,2,2,1,2,1,2,1],
+    [1,2,1,1,2,1,2,1,2,1],
+    [1,2,1,1,2,2,2,2,2,1],
+    [1,2,2,2,2,1,1,1,2,1],
+    [1,1,1,1,1,1,1,1,1,1]
+  ];
+  const pacman = {x:1, y:1};
+  const ghost = {x:8, y:8};
+  let gameOver = false;
 
-const canvas = document.getElementById('game');
-const ctx = canvas.getContext('2d');
-const CELL = 30;
-const level = [
-  [1,1,1,1,1,1,1,1,1,1],
-  [1,2,2,2,2,2,2,2,2,1],
-  [1,2,1,1,1,1,1,1,2,1],
-  [1,2,2,2,2,2,2,1,2,1],
-  [1,1,1,1,1,1,2,1,2,1],
-  [1,2,2,2,2,1,2,1,2,1],
-  [1,2,1,1,2,1,2,1,2,1],
-  [1,2,1,1,2,2,2,2,2,1],
-  [1,2,2,2,2,1,1,1,2,1],
-  [1,1,1,1,1,1,1,1,1,1]
-];
-const pacman = {x:1, y:1};
-const ghost = {x:8, y:8};
-
-let frame = 0;
-const GHOST_DELAY = 10;
-
-let gameOver = false;
-
-function draw(){
-  ctx.clearRect(0,0,canvas.width,canvas.height);
-  for(let y=0;y<10;y++){
-    for(let x=0;x<10;x++){
-      if(level[y][x]===1){
-        ctx.fillStyle='blue';
-        ctx.fillRect(x*CELL,y*CELL,CELL,CELL);
-      }else if(level[y][x]===2){
-        ctx.fillStyle='white';
-        ctx.fillRect(x*CELL+CELL/2-3,y*CELL+CELL/2-3,6,6);
-
+  function draw() {
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    for (let y=0; y<level.length; y++) {
+      for (let x=0; x<level[y].length; x++) {
+        const cell = level[y][x];
+        if (cell === 1) {
+          ctx.fillStyle = 'blue';
+          ctx.fillRect(x*CELL,y*CELL,CELL,CELL);
+        } else {
+          ctx.fillStyle = 'black';
+          ctx.fillRect(x*CELL,y*CELL,CELL,CELL);
+          if (cell === 2) {
+            ctx.fillStyle = 'white';
+            ctx.beginPath();
+            ctx.arc(x*CELL+CELL/2,y*CELL+CELL/2,3,0,Math.PI*2);
+            ctx.fill();
+          }
+        }
       }
     }
+    ctx.fillStyle = 'yellow';
+    ctx.beginPath();
+    ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
+    ctx.fill();
+
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
+    ctx.fill();
   }
-  ctx.fillStyle='yellow';
-  ctx.beginPath();
-  ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
-  ctx.fill();
-  ctx.fillStyle='red';
-  ctx.beginPath();
-  ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
-  ctx.fill();
-}
-function canMove(x,y){
-  return level[y] && level[y][x] !== undefined && level[y][x] !== 1;
 
+  function canMove(x,y) {
+    return level[y] && level[y][x] !== undefined && level[y][x] !== 1;
+  }
 
-}
-function movePacman(dx,dy){
-  const nx=pacman.x+dx;
-  const ny=pacman.y+dy;
-  if(canMove(nx,ny)){
-    pacman.x=nx; pacman.y=ny;
-    if(level[ny][nx]===2){
-      level[ny][nx]=0;
+  function movePacman(dx,dy) {
+    if(gameOver) return;
+    const nx = pacman.x + dx;
+    const ny = pacman.y + dy;
+    if (canMove(nx,ny)) {
+      pacman.x = nx;
+      pacman.y = ny;
+      if (level[ny][nx] === 2) level[ny][nx] = 0;
     }
-
   }
-}
 
-function moveGhost(){
-  const opts=[];
-  if(canMove(ghost.x-1,ghost.y)) opts.push([-1,0]);
-  if(canMove(ghost.x+1,ghost.y)) opts.push([1,0]);
-  if(canMove(ghost.x,ghost.y-1)) opts.push([0,-1]);
-  if(canMove(ghost.x,ghost.y+1)) opts.push([0,1]);
-  const m=opts[Math.floor(Math.random()*opts.length)];
-  ghost.x+=m[0]; ghost.y+=m[1];
-}
-function check(){
-  if(pacman.x===ghost.x && pacman.y===ghost.y){
-    gameOver=true;
-
-
-
+  function moveGhost() {
+    const options = [];
+    if (canMove(ghost.x-1, ghost.y)) options.push([-1,0]);
+    if (canMove(ghost.x+1, ghost.y)) options.push([1,0]);
+    if (canMove(ghost.x, ghost.y-1)) options.push([0,-1]);
+    if (canMove(ghost.x, ghost.y+1)) options.push([0,1]);
+    if (options.length > 0) {
+      const [dx,dy] = options[Math.floor(Math.random()*options.length)];
+      ghost.x += dx;
+      ghost.y += dy;
+    }
   }
-  if(level.every(r=>r.every(c=>c!==2))) gameOver=true;
-}
-document.addEventListener('keydown',e=>{
-  if(gameOver) return;
-  if(e.key==='ArrowUp') movePacman(0,-1);
-  else if(e.key==='ArrowDown') movePacman(0,1);
-  else if(e.key==='ArrowLeft') movePacman(-1,0);
-  else if(e.key==='ArrowRight') movePacman(1,0);
-});
-function setupTouch(){
-  const map={up:[0,-1],down:[0,1],left:[-1,0],right:[1,0]};
-  for(const id in map){
-    const btn=document.getElementById(id);
 
-
-
-
-    btn.addEventListener('touchstart',ev=>{
-
-
-      ev.preventDefault();
-      if(gameOver) return;
-      const [dx,dy]=map[id];
-      movePacman(dx,dy);
-
-
-    };
-    btn.addEventListener('touchstart',handler);
-    btn.addEventListener('mousedown',handler);
-    btn.addEventListener('click',handler);
-
+  function check() {
+    if (pacman.x === ghost.x && pacman.y === ghost.y) {
+      gameOver = true;
+      setTimeout(() => alert('Game Over!'), 10);
+    }
+    if (level.every(row => row.every(cell => cell !== 2))) {
+      gameOver = true;
+      setTimeout(() => alert('You win!'), 10);
+    }
   }
-  if(level.every(r=>r.every(c=>c!==2))) gameOver=true;
-}
 
-
-setupTouch();
-function loop(){
-  if(!gameOver){
-    if(frame % GHOST_DELAY === 0){
+  function loop() {
+    if (!gameOver) {
       moveGhost();
+      check();
+      draw();
+      requestAnimationFrame(loop);
     }
-    check();
-
-
-    });
-
   }
-  draw();
-  if(!gameOver) requestAnimationFrame(loop);
-}
 
-setupTouch();
-function loop(){
-  if(!gameOver){
-    moveGhost();
-    check();
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowUp') movePacman(0,-1);
+    else if (e.key === 'ArrowDown') movePacman(0,1);
+    else if (e.key === 'ArrowLeft') movePacman(-1,0);
+    else if (e.key === 'ArrowRight') movePacman(1,0);
+  });
 
+  function setupButton(id, dx, dy) {
+    const btn = document.getElementById(id);
+    const handler = (ev) => { ev.preventDefault(); movePacman(dx,dy); };
+    ['mousedown','touchstart','click'].forEach(event => btn.addEventListener(event, handler));
   }
-  draw();
-  if(!gameOver) requestAnimationFrame(loop);
-}
+  setupButton('up',0,-1);
+  setupButton('down',0,1);
+  setupButton('left',-1,0);
+  setupButton('right',1,0);
 
-loop();
+  draw();
+  requestAnimationFrame(loop);
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- rewrite Pacman example into a working mini game
- draw a simple board, Pacman, and ghost
- implement keyboard and on-screen touch controls
- random ghost movement and win/lose conditions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856f14c4ff0832484439cb06ad1fa58