### PR TITLE
Implement score display and level transition

### DIFF
--- a/lvl2.html
+++ b/lvl2.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pacman</title>
+<title>Pacman - Level 2</title>
 <style>
   body { background:#000; color:#fff; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
@@ -19,9 +19,10 @@
   <button id="down" style="grid-column:2;grid-row:3;">&#9660;</button>
 </div>
 <div id="scoreDisplay">Score: <span id="score">0</span></div>
-<div id="levelDisplay">Level 1</div>
+<div id="levelDisplay">Level 2</div>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
   const CELL = 30;
@@ -41,9 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const ghost = {x:8, y:8};
   let gameOver = false;
   let frame = 0;
-  const scoreEl = document.getElementById('score');
-  let score = 0;
   const GHOST_DELAY = 10; // move ghost every 10 frames
+  const scoreEl = document.getElementById('score');
+  let score = parseInt(params.get('score') || '0');
+  scoreEl.textContent = score;
 
   function draw() {
     ctx.clearRect(0,0,canvas.width,canvas.height);
@@ -115,9 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (level.every(row => row.every(cell => cell !== 2))) {
       gameOver = true;
-      setTimeout(() => {
-        window.location.href = 'lvl2.html?score=' + score;
-      }, 10);
+      setTimeout(() => alert('You win! Final score: ' + score), 10);
     }
   }
 


### PR DESCRIPTION
## Summary
- add on-screen score and level text below controls
- track collected dots as score
- redirect to lvl2.html when level 1 ends, passing score
- add lvl2.html that receives initial score

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856f14c4ff0832484439cb06ad1fa58