### PR TITLE
Add intro overlay and tweak power pellets

### DIFF
--- a/classifica.html
+++ b/classifica.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Pac5 - Classifica</title>
+<style>
+  body{background:#000;color:#0f0;text-align:center;font-family:sans-serif;}
+</style>
+</head>
+<body>
+<h1>Complimenti!</h1>
+<p>Giocatore: <span id="player"></span></p>
+<p>Punteggio: <span id="score"></span></p>
+<script>
+const params = new URLSearchParams(window.location.search);
+document.getElementById('score').textContent = params.get('score') || '0';
+document.getElementById('player').textContent = sessionStorage.getItem('playerName') || '';
+</script>
+</body>
+</html>

--- a/lvl2.html
+++ b/lvl2.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pac5 - Level 1</title>
+<title>Pac5 - Level 2</title>
 <style>
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
@@ -10,9 +10,6 @@
   #controls button { width:60px; height:60px; font-size:24px; }
   #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
-  #intro{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;color:#0f0;}
-  #intro div{max-width:260px;text-align:center;}
-  #intro button{margin-top:10px;font-size:24px;}
 </style>
 </head>
 <body>
@@ -25,28 +22,20 @@
 </div>
 <div id="playerDisplay">Giocatore: <span id="player"></span></div>
 <div id="scoreDisplay">Score: <span id="score">0</span></div>
-<div id="levelDisplay">Level 1</div>
+<div id="levelDisplay">Level 2</div>
 <div id="message">Game over! Fai tap per ricominciare</div>
-<div id="intro"><div>
-<p>Un gioco. Nessuna guida.<br>5 livelli da affrontare.<br>5 posti nella classifica globale.<br>Solo chi osserva bene, chi sperimenta, chi scopre… potrà ottenere il punteggio più alto.<br><br>Alcune azioni specifiche nascondono un power up, altre power down.<br>Ogni livello nasconde un segreto.<br><br>Chi riesce a completare il gioco… riceverà qualcosa che gli altri non vedranno mai.<br><br>Sarai tu a svelare tutte le hidden mechanics?</p>
-<button id="closeIntro">X</button>
-</div></div>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
-  let playerName = sessionStorage.getItem('playerName');
-  if(!playerName){
-    playerName = prompt('Nome giocatore?') || '';
-    sessionStorage.setItem('playerName', playerName);
-  }
-  document.getElementById('player').textContent = playerName;
+  document.getElementById('player').textContent = sessionStorage.getItem('playerName') || '';
   const CELL = 30;
   const level = [
     [1,1,1,1,1,1,1,1,1,1],
     [1,2,2,0,2,2,0,2,2,1],
     [1,0,1,0,1,1,0,1,0,1],
-    [1,2,0,2,2,2,2,0,2,1],
+    [1,2,0,2,2,3,2,0,2,1],
     [1,1,1,0,1,1,0,1,1,1],
     [1,2,0,2,2,2,2,0,2,1],
     [1,0,1,0,1,1,0,1,0,1],
@@ -55,12 +44,16 @@ document.addEventListener('DOMContentLoaded', () => {
     [1,1,1,1,1,1,1,1,1,1]
   ];
   const pacman = {x:1, y:1};
-  const ghost = {x:8, y:8};
+  const ghost = {x:8, y:8, alive:true};
+  let powered = false;
+  let powerTimer = 0;
+  const POWER_DURATION = 10 * 60; // 10 seconds
   let gameOver = false;
   let frame = 0;
-  const scoreEl = document.getElementById('score');
-  let score = 0;
   const GHOST_DELAY = 10; // move ghost every 10 frames
+  const scoreEl = document.getElementById('score');
+  let score = parseInt(params.get('score') || '0');
+  scoreEl.textContent = score;
 
   if (level[pacman.y][pacman.x] === 2) {
     level[pacman.y][pacman.x] = 0;
@@ -86,10 +79,10 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
           ctx.fillStyle = 'black';
           ctx.fillRect(x*CELL,y*CELL,CELL,CELL);
-          if (cell === 2) {
-            ctx.fillStyle = 'white';
+          if (cell === 2 || cell === 3) {
+            ctx.fillStyle = cell === 3 ? 'orange' : 'white';
             ctx.beginPath();
-            ctx.arc(x*CELL+CELL/2,y*CELL+CELL/2,3,0,Math.PI*2);
+            ctx.arc(x*CELL+CELL/2,y*CELL+CELL/2, cell === 3 ? 6 : 3,0,Math.PI*2);
             ctx.fill();
           }
         }
@@ -100,10 +93,12 @@ document.addEventListener('DOMContentLoaded', () => {
     ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
     ctx.fill();
 
-    ctx.fillStyle = 'red';
-    ctx.beginPath();
-    ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
-    ctx.fill();
+    if(ghost.alive){
+      ctx.fillStyle = 'red';
+      ctx.beginPath();
+      ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
+      ctx.fill();
+    }
   }
 
   function canMove(x,y) {
@@ -117,7 +112,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (canMove(nx,ny)) {
       pacman.x = nx;
       pacman.y = ny;
-      if (level[ny][nx] === 2) {
+      if (level[ny][nx] === 2 || level[ny][nx] === 3) {
+        if (level[ny][nx] === 3) {
+          powered = true;
+          powerTimer = POWER_DURATION;
+        }
         level[ny][nx] = 0;
         score++;
         scoreEl.textContent = score;
@@ -126,6 +125,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function moveGhost() {
+    if(!ghost.alive) return;
     const options = [];
     if (canMove(ghost.x-1, ghost.y)) options.push([-1,0]);
     if (canMove(ghost.x+1, ghost.y)) options.push([1,0]);
@@ -139,13 +139,21 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function check() {
-    if (pacman.x === ghost.x && pacman.y === ghost.y) {
-      showGameOver();
+    if (ghost.alive && pacman.x === ghost.x && pacman.y === ghost.y) {
+      if (powered) {
+        ghost.alive = false;
+        ghost.x = -1;
+        ghost.y = -1;
+        score += 60;
+        scoreEl.textContent = score;
+      } else {
+        showGameOver();
+      }
     }
-    if (level.every(row => row.every(cell => cell !== 2))) {
+    if (level.every(row => row.every(cell => cell !== 2 && cell !== 3))) {
       gameOver = true;
       setTimeout(() => {
-        window.location.href = 'lvl2.html?score=' + score;
+        window.location.href = 'lvl3.html?score=' + score;
       }, 10);
     }
   }
@@ -154,6 +162,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!gameOver) {
       if (frame % GHOST_DELAY === 0) moveGhost();
       frame++;
+      if (powerTimer > 0) {
+        powerTimer--;
+        if (powerTimer === 0) powered = false;
+      }
       check();
       draw();
       requestAnimationFrame(loop);
@@ -178,11 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setupButton('right',1,0);
 
   draw();
-  const intro = document.getElementById('intro');
-  document.getElementById('closeIntro').addEventListener('click', () => {
-    intro.style.display = 'none';
-    requestAnimationFrame(loop);
-  });
+  requestAnimationFrame(loop);
 });
 </script>
 </body>

--- a/lvl3.html
+++ b/lvl3.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pac5 - Level 1</title>
+<title>Pac5 - Level 3</title>
 <style>
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
@@ -10,9 +10,7 @@
   #controls button { width:60px; height:60px; font-size:24px; }
   #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
-  #intro{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;color:#0f0;}
-  #intro div{max-width:260px;text-align:center;}
-  #intro button{margin-top:10px;font-size:24px;}
+  #timerDisplay { margin-top:5px; font-size:12px; }
 </style>
 </head>
 <body>
@@ -25,22 +23,15 @@
 </div>
 <div id="playerDisplay">Giocatore: <span id="player"></span></div>
 <div id="scoreDisplay">Score: <span id="score">0</span></div>
-<div id="levelDisplay">Level 1</div>
+<div id="levelDisplay">Level 3</div>
 <div id="message">Game over! Fai tap per ricominciare</div>
-<div id="intro"><div>
-<p>Un gioco. Nessuna guida.<br>5 livelli da affrontare.<br>5 posti nella classifica globale.<br>Solo chi osserva bene, chi sperimenta, chi scopre… potrà ottenere il punteggio più alto.<br><br>Alcune azioni specifiche nascondono un power up, altre power down.<br>Ogni livello nasconde un segreto.<br><br>Chi riesce a completare il gioco… riceverà qualcosa che gli altri non vedranno mai.<br><br>Sarai tu a svelare tutte le hidden mechanics?</p>
-<button id="closeIntro">X</button>
-</div></div>
+<div id="timerDisplay">Tempo: <span id="timer">5</span></div>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
-  let playerName = sessionStorage.getItem('playerName');
-  if(!playerName){
-    playerName = prompt('Nome giocatore?') || '';
-    sessionStorage.setItem('playerName', playerName);
-  }
-  document.getElementById('player').textContent = playerName;
+  document.getElementById('player').textContent = sessionStorage.getItem('playerName') || '';
   const CELL = 30;
   const level = [
     [1,1,1,1,1,1,1,1,1,1],
@@ -55,18 +46,19 @@ document.addEventListener('DOMContentLoaded', () => {
     [1,1,1,1,1,1,1,1,1,1]
   ];
   const pacman = {x:1, y:1};
-  const ghost = {x:8, y:8};
   let gameOver = false;
   let frame = 0;
   const scoreEl = document.getElementById('score');
-  let score = 0;
-  const GHOST_DELAY = 10; // move ghost every 10 frames
+  let score = parseInt(params.get('score') || '0');
+  scoreEl.textContent = score;
 
   if (level[pacman.y][pacman.x] === 2) {
     level[pacman.y][pacman.x] = 0;
-    score++;
+    score += 2;
     scoreEl.textContent = score;
   }
+  let timer = 5 * 60;
+  const timerEl = document.getElementById("timer");
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
@@ -100,10 +92,6 @@ document.addEventListener('DOMContentLoaded', () => {
     ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
     ctx.fill();
 
-    ctx.fillStyle = 'red';
-    ctx.beginPath();
-    ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
-    ctx.fill();
   }
 
   function canMove(x,y) {
@@ -119,43 +107,34 @@ document.addEventListener('DOMContentLoaded', () => {
       pacman.y = ny;
       if (level[ny][nx] === 2) {
         level[ny][nx] = 0;
-        score++;
+        score+=2;
         scoreEl.textContent = score;
       }
     }
   }
-
-  function moveGhost() {
-    const options = [];
-    if (canMove(ghost.x-1, ghost.y)) options.push([-1,0]);
-    if (canMove(ghost.x+1, ghost.y)) options.push([1,0]);
-    if (canMove(ghost.x, ghost.y-1)) options.push([0,-1]);
-    if (canMove(ghost.x, ghost.y+1)) options.push([0,1]);
-    if (options.length > 0) {
-      const [dx,dy] = options[Math.floor(Math.random()*options.length)];
-      ghost.x += dx;
-      ghost.y += dy;
-    }
-  }
-
   function check() {
-    if (pacman.x === ghost.x && pacman.y === ghost.y) {
-      showGameOver();
-    }
     if (level.every(row => row.every(cell => cell !== 2))) {
       gameOver = true;
       setTimeout(() => {
-        window.location.href = 'lvl2.html?score=' + score;
+        window.location.href = "lvl4.html?score=" + score;
+      }, 10);
+    }
+    if (timer-- <= 0) {
+      gameOver = true;
+      setTimeout(() => {
+        window.location.href = "lvl4.html?score=" + score;
       }, 10);
     }
   }
 
+
+
   function loop() {
     if (!gameOver) {
-      if (frame % GHOST_DELAY === 0) moveGhost();
       frame++;
       check();
       draw();
+      timerEl.textContent = Math.ceil(timer/60);
       requestAnimationFrame(loop);
     }
   }
@@ -178,11 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setupButton('right',1,0);
 
   draw();
-  const intro = document.getElementById('intro');
-  document.getElementById('closeIntro').addEventListener('click', () => {
-    intro.style.display = 'none';
-    requestAnimationFrame(loop);
-  });
+  requestAnimationFrame(loop);
 });
 </script>
 </body>

--- a/lvl4.html
+++ b/lvl4.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pac5 - Level 1</title>
+<title>Pac5 - Level 4</title>
 <style>
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
@@ -10,9 +10,7 @@
   #controls button { width:60px; height:60px; font-size:24px; }
   #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
-  #intro{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;color:#0f0;}
-  #intro div{max-width:260px;text-align:center;}
-  #intro button{margin-top:10px;font-size:24px;}
+  #timerDisplay { margin-top:5px; font-size:12px; }
 </style>
 </head>
 <body>
@@ -25,48 +23,42 @@
 </div>
 <div id="playerDisplay">Giocatore: <span id="player"></span></div>
 <div id="scoreDisplay">Score: <span id="score">0</span></div>
-<div id="levelDisplay">Level 1</div>
+<div id="levelDisplay">Level 4</div>
+<div id="timerDisplay">Tempo: <span id="timer">20</span></div>
 <div id="message">Game over! Fai tap per ricominciare</div>
-<div id="intro"><div>
-<p>Un gioco. Nessuna guida.<br>5 livelli da affrontare.<br>5 posti nella classifica globale.<br>Solo chi osserva bene, chi sperimenta, chi scopre… potrà ottenere il punteggio più alto.<br><br>Alcune azioni specifiche nascondono un power up, altre power down.<br>Ogni livello nasconde un segreto.<br><br>Chi riesce a completare il gioco… riceverà qualcosa che gli altri non vedranno mai.<br><br>Sarai tu a svelare tutte le hidden mechanics?</p>
-<button id="closeIntro">X</button>
-</div></div>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
-  let playerName = sessionStorage.getItem('playerName');
-  if(!playerName){
-    playerName = prompt('Nome giocatore?') || '';
-    sessionStorage.setItem('playerName', playerName);
-  }
-  document.getElementById('player').textContent = playerName;
+  document.getElementById('player').textContent = sessionStorage.getItem('playerName') || '';
   const CELL = 30;
   const level = [
     [1,1,1,1,1,1,1,1,1,1],
-    [1,2,2,0,2,2,0,2,2,1],
-    [1,0,1,0,1,1,0,1,0,1],
     [1,2,0,2,2,2,2,0,2,1],
+    [1,2,0,1,1,1,1,0,2,1],
+    [1,2,2,2,0,0,2,2,2,1],
     [1,1,1,0,1,1,0,1,1,1],
+    [1,2,2,2,0,0,2,2,2,1],
+    [1,2,0,1,1,1,1,0,2,1],
     [1,2,0,2,2,2,2,0,2,1],
-    [1,0,1,0,1,1,0,1,0,1],
-    [1,2,2,0,2,2,0,2,2,1],
-    [1,2,2,2,0,2,2,2,2,1],
+    [1,2,2,2,2,2,2,2,2,1],
     [1,1,1,1,1,1,1,1,1,1]
   ];
   const pacman = {x:1, y:1};
-  const ghost = {x:8, y:8};
   let gameOver = false;
   let frame = 0;
+  let timer = 20 * 60; // 20 second time limit
   const scoreEl = document.getElementById('score');
-  let score = 0;
-  const GHOST_DELAY = 10; // move ghost every 10 frames
-
+  let score = parseInt(params.get('score') || '0');
+  scoreEl.textContent = score;
+  const timerEl = document.getElementById('timer');
   if (level[pacman.y][pacman.x] === 2) {
     level[pacman.y][pacman.x] = 0;
     score++;
     scoreEl.textContent = score;
   }
+
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
@@ -100,10 +92,6 @@ document.addEventListener('DOMContentLoaded', () => {
     ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
     ctx.fill();
 
-    ctx.fillStyle = 'red';
-    ctx.beginPath();
-    ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
-    ctx.fill();
   }
 
   function canMove(x,y) {
@@ -125,37 +113,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function moveGhost() {
-    const options = [];
-    if (canMove(ghost.x-1, ghost.y)) options.push([-1,0]);
-    if (canMove(ghost.x+1, ghost.y)) options.push([1,0]);
-    if (canMove(ghost.x, ghost.y-1)) options.push([0,-1]);
-    if (canMove(ghost.x, ghost.y+1)) options.push([0,1]);
-    if (options.length > 0) {
-      const [dx,dy] = options[Math.floor(Math.random()*options.length)];
-      ghost.x += dx;
-      ghost.y += dy;
-    }
-  }
-
   function check() {
-    if (pacman.x === ghost.x && pacman.y === ghost.y) {
+    if (timer-- <= 0) {
       showGameOver();
     }
     if (level.every(row => row.every(cell => cell !== 2))) {
       gameOver = true;
       setTimeout(() => {
-        window.location.href = 'lvl2.html?score=' + score;
+        window.location.href = 'lvl5.html?score=' + score;
       }, 10);
     }
   }
 
   function loop() {
     if (!gameOver) {
-      if (frame % GHOST_DELAY === 0) moveGhost();
       frame++;
       check();
       draw();
+      timerEl.textContent = Math.ceil(timer/60);
       requestAnimationFrame(loop);
     }
   }
@@ -178,11 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setupButton('right',1,0);
 
   draw();
-  const intro = document.getElementById('intro');
-  document.getElementById('closeIntro').addEventListener('click', () => {
-    intro.style.display = 'none';
-    requestAnimationFrame(loop);
-  });
+  requestAnimationFrame(loop);
 });
 </script>
 </body>

--- a/lvl5.html
+++ b/lvl5.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pac5 - Level 1</title>
+<title>Pac5 - Level 5</title>
 <style>
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
@@ -10,9 +10,6 @@
   #controls button { width:60px; height:60px; font-size:24px; }
   #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
-  #intro{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:flex;align-items:center;justify-content:center;color:#0f0;}
-  #intro div{max-width:260px;text-align:center;}
-  #intro button{margin-top:10px;font-size:24px;}
 </style>
 </head>
 <body>
@@ -25,42 +22,41 @@
 </div>
 <div id="playerDisplay">Giocatore: <span id="player"></span></div>
 <div id="scoreDisplay">Score: <span id="score">0</span></div>
-<div id="levelDisplay">Level 1</div>
+<div id="levelDisplay">Level 5</div>
 <div id="message">Game over! Fai tap per ricominciare</div>
-<div id="intro"><div>
-<p>Un gioco. Nessuna guida.<br>5 livelli da affrontare.<br>5 posti nella classifica globale.<br>Solo chi osserva bene, chi sperimenta, chi scopre… potrà ottenere il punteggio più alto.<br><br>Alcune azioni specifiche nascondono un power up, altre power down.<br>Ogni livello nasconde un segreto.<br><br>Chi riesce a completare il gioco… riceverà qualcosa che gli altri non vedranno mai.<br><br>Sarai tu a svelare tutte le hidden mechanics?</p>
-<button id="closeIntro">X</button>
-</div></div>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
-  let playerName = sessionStorage.getItem('playerName');
-  if(!playerName){
-    playerName = prompt('Nome giocatore?') || '';
-    sessionStorage.setItem('playerName', playerName);
-  }
-  document.getElementById('player').textContent = playerName;
+  document.getElementById('player').textContent = sessionStorage.getItem('playerName') || '';
   const CELL = 30;
   const level = [
     [1,1,1,1,1,1,1,1,1,1],
     [1,2,2,0,2,2,0,2,2,1],
-    [1,0,1,0,1,1,0,1,0,1],
-    [1,2,0,2,2,2,2,0,2,1],
+    [1,2,1,1,0,1,1,1,2,1],
+    [1,2,0,2,2,3,2,0,2,1],
     [1,1,1,0,1,1,0,1,1,1],
     [1,2,0,2,2,2,2,0,2,1],
-    [1,0,1,0,1,1,0,1,0,1],
+    [1,2,1,1,0,1,1,1,2,1],
     [1,2,2,0,2,2,0,2,2,1],
-    [1,2,2,2,0,2,2,2,2,1],
+    [1,2,2,2,2,2,2,2,2,1],
     [1,1,1,1,1,1,1,1,1,1]
   ];
   const pacman = {x:1, y:1};
-  const ghost = {x:8, y:8};
+  const ghosts = [
+    {x:8, y:8, startX:8, startY:8},
+    {x:1, y:8, startX:1, startY:8}
+  ];
+  let powered = false;
+  let powerTimer = 0;
+  const POWER_DURATION = 10 * 60;
   let gameOver = false;
   let frame = 0;
-  const scoreEl = document.getElementById('score');
-  let score = 0;
   const GHOST_DELAY = 10; // move ghost every 10 frames
+  const scoreEl = document.getElementById('score');
+  let score = parseInt(params.get('score') || '0');
+  scoreEl.textContent = score;
 
   if (level[pacman.y][pacman.x] === 2) {
     level[pacman.y][pacman.x] = 0;
@@ -86,10 +82,10 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
           ctx.fillStyle = 'black';
           ctx.fillRect(x*CELL,y*CELL,CELL,CELL);
-          if (cell === 2) {
-            ctx.fillStyle = 'white';
+          if (cell === 2 || cell === 3) {
+            ctx.fillStyle = cell === 3 ? 'orange' : 'white';
             ctx.beginPath();
-            ctx.arc(x*CELL+CELL/2,y*CELL+CELL/2,3,0,Math.PI*2);
+            ctx.arc(x*CELL+CELL/2,y*CELL+CELL/2, cell === 3 ? 6 : 3,0,Math.PI*2);
             ctx.fill();
           }
         }
@@ -100,10 +96,12 @@ document.addEventListener('DOMContentLoaded', () => {
     ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
     ctx.fill();
 
-    ctx.fillStyle = 'red';
-    ctx.beginPath();
-    ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
-    ctx.fill();
+    ghosts.forEach(g => {
+      ctx.fillStyle = 'red';
+      ctx.beginPath();
+      ctx.arc(g.x*CELL+CELL/2,g.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
+      ctx.fill();
+    });
   }
 
   function canMove(x,y) {
@@ -117,7 +115,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (canMove(nx,ny)) {
       pacman.x = nx;
       pacman.y = ny;
-      if (level[ny][nx] === 2) {
+      if (level[ny][nx] === 2 || level[ny][nx] === 3) {
+        if (level[ny][nx] === 3) {
+          powered = true;
+          powerTimer = POWER_DURATION;
+        }
         level[ny][nx] = 0;
         score++;
         scoreEl.textContent = score;
@@ -125,35 +127,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function moveGhost() {
-    const options = [];
-    if (canMove(ghost.x-1, ghost.y)) options.push([-1,0]);
-    if (canMove(ghost.x+1, ghost.y)) options.push([1,0]);
-    if (canMove(ghost.x, ghost.y-1)) options.push([0,-1]);
-    if (canMove(ghost.x, ghost.y+1)) options.push([0,1]);
-    if (options.length > 0) {
-      const [dx,dy] = options[Math.floor(Math.random()*options.length)];
-      ghost.x += dx;
-      ghost.y += dy;
-    }
+  function moveGhosts() {
+    ghosts.forEach(g => {
+      const options = [];
+      if (canMove(g.x-1, g.y)) options.push([-1,0]);
+      if (canMove(g.x+1, g.y)) options.push([1,0]);
+      if (canMove(g.x, g.y-1)) options.push([0,-1]);
+      if (canMove(g.x, g.y+1)) options.push([0,1]);
+      if (options.length > 0) {
+        const [dx,dy] = options[Math.floor(Math.random()*options.length)];
+        g.x += dx;
+        g.y += dy;
+      }
+    });
   }
 
   function check() {
-    if (pacman.x === ghost.x && pacman.y === ghost.y) {
-      showGameOver();
-    }
-    if (level.every(row => row.every(cell => cell !== 2))) {
+    ghosts.forEach(g => {
+      if (pacman.x === g.x && pacman.y === g.y) {
+        if (powered) {
+          score += 60;
+          scoreEl.textContent = score;
+          g.x = g.startX;
+          g.y = g.startY;
+        } else {
+          showGameOver();
+        }
+      }
+    });
+    if (level.every(row => row.every(cell => cell !== 2 && cell !== 3))) {
       gameOver = true;
       setTimeout(() => {
-        window.location.href = 'lvl2.html?score=' + score;
+        window.location.href = 'classifica.html?score=' + score;
       }, 10);
     }
   }
 
   function loop() {
     if (!gameOver) {
-      if (frame % GHOST_DELAY === 0) moveGhost();
+      if (frame % GHOST_DELAY === 0) moveGhosts();
       frame++;
+      if (powerTimer > 0) {
+        powerTimer--;
+        if (powerTimer === 0) powered = false;
+      }
       check();
       draw();
       requestAnimationFrame(loop);
@@ -178,11 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setupButton('right',1,0);
 
   draw();
-  const intro = document.getElementById('intro');
-  document.getElementById('closeIntro').addEventListener('click', () => {
-    intro.style.display = 'none';
-    requestAnimationFrame(loop);
-  });
+  requestAnimationFrame(loop);
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- shrink score and level text
- add intro overlay on level 1 with dismiss button
- start game only after closing the intro
- make level 5 power-up give 10 seconds to eat ghosts

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6856f14c4ff0832484439cb06ad1fa58