### PR TITLE
Add slow ghost to level 4 and tweak UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
 
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
-  #controls { width:180px; margin:10px auto; display:grid; grid-template-columns:60px 60px 60px; grid-template-rows:60px 60px 60px; gap:5px; }
-  #controls button { width:60px; height:60px; font-size:24px; }
-  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
+  #controls { width:150px; margin:10px auto; display:grid; grid-template-columns:50px 50px 50px; grid-template-rows:50px 50px 50px; gap:5px; }
+  #controls button { width:50px; height:50px; font-size:24px; }
+  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:36px; color:#0f0; }
 
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
   #intro{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);display:none;align-items:center;justify-content:center;color:#0f0;}
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
-    msg.style.display = 'block';
+    msg.style.display = 'flex';
     const restart = () => { window.location.href = 'index.html'; };
     ['keydown','mousedown','touchstart'].forEach(ev => window.addEventListener(ev, restart, {once:true}));
   }

--- a/lvl2.html
+++ b/lvl2.html
@@ -7,9 +7,9 @@
 
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
-  #controls { width:180px; margin:10px auto; display:grid; grid-template-columns:60px 60px 60px; grid-template-rows:60px 60px 60px; gap:5px; }
-  #controls button { width:60px; height:60px; font-size:24px; }
-  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
+  #controls { width:150px; margin:10px auto; display:grid; grid-template-columns:50px 50px 50px; grid-template-rows:50px 50px 50px; gap:5px; }
+  #controls button { width:50px; height:50px; font-size:24px; }
+  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:36px; color:#0f0; }
 
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
 
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
-    msg.style.display = 'block';
+    msg.style.display = 'flex';
     const restart = () => { window.location.href = 'index.html'; };
     ['keydown','mousedown','touchstart'].forEach(ev => window.addEventListener(ev, restart, {once:true}));
   }

--- a/lvl3.html
+++ b/lvl3.html
@@ -7,9 +7,9 @@
 
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
-  #controls { width:180px; margin:10px auto; display:grid; grid-template-columns:60px 60px 60px; grid-template-rows:60px 60px 60px; gap:5px; }
-  #controls button { width:60px; height:60px; font-size:24px; }
-  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
+  #controls { width:150px; margin:10px auto; display:grid; grid-template-columns:50px 50px 50px; grid-template-rows:50px 50px 50px; gap:5px; }
+  #controls button { width:50px; height:50px; font-size:24px; }
+  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:36px; color:#0f0; }
 
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
   #timerDisplay { margin-top:5px; font-size:12px; }
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
-    msg.style.display = 'block';
+    msg.style.display = 'flex';
     const restart = () => { window.location.href = 'index.html'; };
     ['keydown','mousedown','touchstart'].forEach(ev => window.addEventListener(ev, restart, {once:true}));
   }

--- a/lvl4.html
+++ b/lvl4.html
@@ -6,9 +6,9 @@
 <style>
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
-  #controls { width:180px; margin:10px auto; display:grid; grid-template-columns:60px 60px 60px; grid-template-rows:60px 60px 60px; gap:5px; }
-  #controls button { width:60px; height:60px; font-size:24px; }
-  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
+  #controls { width:150px; margin:10px auto; display:grid; grid-template-columns:50px 50px 50px; grid-template-rows:50px 50px 50px; gap:5px; }
+  #controls button { width:50px; height:50px; font-size:24px; }
+  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:36px; color:#0f0; }
 
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
   #timerDisplay { margin-top:5px; font-size:12px; }
@@ -42,9 +42,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const CELL = 30;
   const level = LEVELS[4].map(r => r.slice());
   const pacman = {x:1, y:1};
+  const ghost = {x:8, y:8};
 
   let gameOver = false;
   let frame = 0;
+  const GHOST_DELAY = 40; // ghost moves very slowly
   let timer = 20 * 60; // 20 second time limit
   const scoreEl = document.getElementById('score');
   let score = parseInt(params.get('score') || '0');
@@ -60,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
-    msg.style.display = 'block';
+    msg.style.display = 'flex';
     const restart = () => { window.location.href = 'index.html'; };
     ['keydown','mousedown','touchstart'].forEach(ev => window.addEventListener(ev, restart, {once:true}));
   }
@@ -91,6 +93,11 @@ document.addEventListener('DOMContentLoaded', () => {
     ctx.arc(pacman.x*CELL+CELL/2,pacman.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
     ctx.fill();
 
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(ghost.x*CELL+CELL/2,ghost.y*CELL+CELL/2,CELL/2-2,0,Math.PI*2);
+    ctx.fill();
+
   }
 
   function canMove(x,y) {
@@ -112,8 +119,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function moveGhost() {
+    const options = [];
+    if (canMove(ghost.x-1, ghost.y)) options.push([-1,0]);
+    if (canMove(ghost.x+1, ghost.y)) options.push([1,0]);
+    if (canMove(ghost.x, ghost.y-1)) options.push([0,-1]);
+    if (canMove(ghost.x, ghost.y+1)) options.push([0,1]);
+    if (options.length > 0) {
+      const [dx,dy] = options[Math.floor(Math.random()*options.length)];
+      ghost.x += dx;
+      ghost.y += dy;
+    }
+  }
+
 
   function check() {
+    if (pacman.x === ghost.x && pacman.y === ghost.y) {
+      showGameOver();
+    }
     if (timer-- <= 0) {
       showGameOver();
 
@@ -129,6 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function loop() {
     if (!gameOver) {
 
+      if (frame % GHOST_DELAY === 0) moveGhost();
       frame++;
       check();
       draw();

--- a/lvl5.html
+++ b/lvl5.html
@@ -7,9 +7,9 @@
 
   body { background:#000; color:#0f0; text-align:center; font-family:sans-serif; }
   canvas { background:#000; display:block; margin:10px auto; border:2px solid #fff; touch-action:none; }
-  #controls { width:180px; margin:10px auto; display:grid; grid-template-columns:60px 60px 60px; grid-template-rows:60px 60px 60px; gap:5px; }
-  #controls button { width:60px; height:60px; font-size:24px; }
-  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:24px; color:#0f0; }
+  #controls { width:150px; margin:10px auto; display:grid; grid-template-columns:50px 50px 50px; grid-template-rows:50px 50px 50px; gap:5px; }
+  #controls button { width:50px; height:50px; font-size:24px; }
+  #message { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; font-size:36px; color:#0f0; }
 
   #playerDisplay,#scoreDisplay,#levelDisplay{font-size:14px;margin-top:4px;}
 
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function showGameOver(){
     gameOver = true;
     const msg = document.getElementById('message');
-    msg.style.display = 'block';
+    msg.style.display = 'flex';
     const restart = () => { window.location.href = 'index.html'; };
     ['keydown','mousedown','touchstart'].forEach(ev => window.addEventListener(ev, restart, {once:true}));
   }


### PR DESCRIPTION
## Summary
- make overlay text larger
- reduce the size of on‑screen arrows
- display game over overlay using flex for centering
- introduce a very slow ghost in level 4

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685921ed610c83249f85eb1965bae5e1