### PR TITLE
Add ghost escape behavior and adjust controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,11 +157,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentDir = null;
   let speed = 1;
   let lastPress = 0;
+  const MAX_SPEED = 3;
 
   function startMove(dx,dy){
     const now = Date.now();
-    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 200){
-      speed = Math.min(speed+1,5);
+    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 300){
+      speed = Math.min(speed+1,MAX_SPEED);
     } else {
       speed = 1;
       currentDir = {dx,dy};
@@ -178,7 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function autoMove(){
     if(currentDir){
       for(let i=0;i<speed;i++) movePacman(currentDir.dx,currentDir.dy);
-      if(Date.now()-lastPress>300 && speed>1) speed--;
+      if(Date.now()-lastPress>400 && speed>1) speed--;
     }
   }
 

--- a/lvl2.html
+++ b/lvl2.html
@@ -132,29 +132,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if(!ghost.alive) return;
 
-    const targeted = [];
     const randOptions = [];
+    const targeted = [];
 
     if (canMove(ghost.x-1, ghost.y)) {
       randOptions.push([-1,0]);
-      if (pacman.x < ghost.x) targeted.push([-1,0]);
+      if (!powered && pacman.x < ghost.x) targeted.push([-1,0]);
     }
     if (canMove(ghost.x+1, ghost.y)) {
       randOptions.push([1,0]);
-      if (pacman.x > ghost.x) targeted.push([1,0]);
+      if (!powered && pacman.x > ghost.x) targeted.push([1,0]);
     }
     if (canMove(ghost.x, ghost.y-1)) {
       randOptions.push([0,-1]);
-      if (pacman.y < ghost.y) targeted.push([0,-1]);
+      if (!powered && pacman.y < ghost.y) targeted.push([0,-1]);
     }
     if (canMove(ghost.x, ghost.y+1)) {
       randOptions.push([0,1]);
-      if (pacman.y > ghost.y) targeted.push([0,1]);
+      if (!powered && pacman.y > ghost.y) targeted.push([0,1]);
     }
 
-    let options = targeted;
-    if (Math.random() < 0.3 || options.length === 0) {
+    let options;
+    if (powered) {
       options = randOptions;
+      let bestDist = -1;
+      let best = [];
+      options.forEach(([dx,dy]) => {
+        const nx = ghost.x + dx;
+        const ny = ghost.y + dy;
+        const dist = Math.abs(nx - pacman.x) + Math.abs(ny - pacman.y);
+        if (dist > bestDist) {
+          bestDist = dist;
+          best = [[dx,dy]];
+        } else if (dist === bestDist) {
+          best.push([dx,dy]);
+        }
+      });
+      if (best.length > 0) {
+        options = best;
+      }
+    } else {
+      options = targeted;
+      if (Math.random() < 0.3 || options.length === 0) {
+        options = randOptions;
+      }
     }
     if (options.length > 0) {
       const [dx,dy] = options[Math.floor(Math.random()*options.length)];
@@ -190,11 +211,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentDir = null;
   let speed = 1;
   let lastPress = 0;
+  const MAX_SPEED = 3;
 
   function startMove(dx,dy){
     const now = Date.now();
-    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 200){
-      speed = Math.min(speed+1,5);
+    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 300){
+      speed = Math.min(speed+1,MAX_SPEED);
     } else {
       speed = 1;
       currentDir = {dx,dy};
@@ -211,7 +233,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function autoMove(){
     if(currentDir){
       for(let i=0;i<speed;i++) movePacman(currentDir.dx,currentDir.dy);
-      if(Date.now()-lastPress>300 && speed>1) speed--;
+      if(Date.now()-lastPress>400 && speed>1) speed--;
     }
   }
 

--- a/lvl3.html
+++ b/lvl3.html
@@ -132,11 +132,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentDir = null;
   let speed = 1;
   let lastPress = 0;
+  const MAX_SPEED = 3;
 
   function startMove(dx,dy){
     const now = Date.now();
-    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 200){
-      speed = Math.min(speed+1,5);
+    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 300){
+      speed = Math.min(speed+1,MAX_SPEED);
     } else {
       speed = 1;
       currentDir = {dx,dy};
@@ -153,7 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function autoMove(){
     if(currentDir){
       for(let i=0;i<speed;i++) movePacman(currentDir.dx,currentDir.dy);
-      if(Date.now()-lastPress>300 && speed>1) speed--;
+      if(Date.now()-lastPress>400 && speed>1) speed--;
     }
   }
 

--- a/lvl4.html
+++ b/lvl4.html
@@ -166,11 +166,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentDir = null;
   let speed = 1;
   let lastPress = 0;
+  const MAX_SPEED = 3;
 
   function startMove(dx,dy){
     const now = Date.now();
-    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 200){
-      speed = Math.min(speed+1,5);
+    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 300){
+      speed = Math.min(speed+1,MAX_SPEED);
     } else {
       speed = 1;
       currentDir = {dx,dy};
@@ -187,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function autoMove(){
     if(currentDir){
       for(let i=0;i<speed;i++) movePacman(currentDir.dx,currentDir.dy);
-      if(Date.now()-lastPress>300 && speed>1) speed--;
+      if(Date.now()-lastPress>400 && speed>1) speed--;
     }
   }
 

--- a/lvl5.html
+++ b/lvl5.html
@@ -44,11 +44,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const ghosts = [
     {x:7, y:7, alive:true},
     {x:8, y:7, alive:true},
-    {x:7, y:8, alive:true}
+    {x:7, y:8, alive:true},
+    {x:8, y:8, alive:true},
+    {x:6, y:7, alive:true}
   ];
   let powered = false;
   let powerTimer = 0;
   const POWER_DURATION = 10 * 60;
+  let ghostEatTimer = -1;
+  let ghostsEaten = 0;
 
   let gameOver = false;
   let frame = 0;
@@ -128,6 +132,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (level[ny][nx] === 3) {
           powered = true;
           powerTimer = POWER_DURATION;
+          ghostEatTimer = 5 * 60;
+          ghostsEaten = 0;
         }
 
         level[ny][nx] = 0;
@@ -148,9 +154,28 @@ document.addEventListener('DOMContentLoaded', () => {
       if (canMove(g.x, g.y-1)) options.push([0,-1]);
       if (canMove(g.x, g.y+1)) options.push([0,1]);
       if (options.length > 0) {
-        const [dx,dy] = options[Math.floor(Math.random()*options.length)];
-        g.x += dx;
-        g.y += dy;
+        if (powered) {
+          let bestDist = -1;
+          let best = [];
+          options.forEach(([dx,dy]) => {
+            const nx = g.x + dx;
+            const ny = g.y + dy;
+            const dist = Math.abs(nx - pacman.x) + Math.abs(ny - pacman.y);
+            if (dist > bestDist) {
+              bestDist = dist;
+              best = [[dx,dy]];
+            } else if (dist === bestDist) {
+              best.push([dx,dy]);
+            }
+          });
+          const [dx,dy] = best[Math.floor(Math.random()*best.length)];
+          g.x += dx;
+          g.y += dy;
+        } else {
+          const [dx,dy] = options[Math.floor(Math.random()*options.length)];
+          g.x += dx;
+          g.y += dy;
+        }
       }
     });
   }
@@ -164,6 +189,14 @@ document.addEventListener('DOMContentLoaded', () => {
           score += 60;
           scoreEl.textContent = score;
           g.alive = false;
+          ghostsEaten++;
+          if(ghostEatTimer > 0 && ghostsEaten === 5){
+            for(let y=0; y<level.length; y++){
+              for(let x=0; x<level[y].length; x++){
+                if(level[y][x] === 0) level[y][x] = 2;
+              }
+            }
+          }
         } else {
           showGameOver();
 
@@ -183,11 +216,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentDir = null;
   let speed = 1;
   let lastPress = 0;
+  const MAX_SPEED = 3;
 
   function startMove(dx,dy){
     const now = Date.now();
-    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 200){
-      speed = Math.min(speed+1,5);
+    if(currentDir && currentDir.dx===dx && currentDir.dy===dy && now-lastPress < 300){
+      speed = Math.min(speed+1,MAX_SPEED);
     } else {
       speed = 1;
       currentDir = {dx,dy};
@@ -204,7 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function autoMove(){
     if(currentDir){
       for(let i=0;i<speed;i++) movePacman(currentDir.dx,currentDir.dy);
-      if(Date.now()-lastPress>300 && speed>1) speed--;
+      if(Date.now()-lastPress>400 && speed>1) speed--;
     }
   }
 
@@ -216,6 +250,13 @@ document.addEventListener('DOMContentLoaded', () => {
       if (powerTimer > 0) {
         powerTimer--;
         if (powerTimer === 0) powered = false;
+      }
+      if(ghostEatTimer > 0){
+        ghostEatTimer--;
+        if(ghostEatTimer === 0){
+          ghostEatTimer = -1;
+          ghostsEaten = 0;
+        }
       }
 
       autoMove();


### PR DESCRIPTION
## Summary
- slower and less sensitive player controls
- ghosts now escape pacman when power-ups are active
- add 2 extra ghosts in level 5
- eating all 5 ghosts within 5 seconds spawns new pellets in level 5

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685928f37e3883249c767851978d54ab